### PR TITLE
Make search by stock relevant to search by name

### DIFF
--- a/src/main/java/io/github/lightman314/lightmanscurrency/api/traders/terminal/FilterUtils.java
+++ b/src/main/java/io/github/lightman314/lightmanscurrency/api/traders/terminal/FilterUtils.java
@@ -1,12 +1,12 @@
 package io.github.lightman314.lightmanscurrency.api.traders.terminal;
 
-import io.github.lightman314.lightmanscurrency.api.traders.TradeContext;
 import io.github.lightman314.lightmanscurrency.api.traders.TraderData;
-import io.github.lightman314.lightmanscurrency.api.traders.trade.TradeData;
-import io.github.lightman314.lightmanscurrency.common.traders.terminal.filters.BasicSearchFilter;
+import io.github.lightman314.lightmanscurrency.common.traders.terminal.filters.ItemTraderSearchFilter;
 import net.minecraft.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -132,16 +132,86 @@ public class FilterUtils {
         });
     }
 
-    public static void checkStock(PendingSearch search, TraderData trader) {
-        int stockCount = 0;
-        TradeContext context = TradeContext.createStorageMode(trader);
-        for(TradeData trade : trader.getTradeData())
-        {
-            if(trade.isValid() && trade.hasStock(context))
-                stockCount++;
-        }
-        intRange(search,BasicSearchFilter.STOCK_COUNT,stockCount);
+    public static StockRequirement getStockRequirement(PendingSearch search, TraderData trader) {
+        AtomicBoolean hasFrom = new AtomicBoolean(false);
+        AtomicInteger from = new AtomicInteger(0);
+        AtomicBoolean hasTo = new AtomicBoolean(false);
+        AtomicInteger to = new AtomicInteger(0);
+        var filter = ItemTraderSearchFilter.STOCK_COUNT;
+        search.processUnfiltered(input -> {
+            try {
+                if (!input.startsWith(filter))
+                    return false;
+                input = input.substring(filter.length());
+                if (input.startsWith(">=")) {
+                    from.set(Integer.parseInt(input.substring(2)));
+                    hasFrom.set(true);
+                    return true;
+                }
+                if (input.startsWith(">")) {
+                    from.set(Integer.parseInt(input.substring(1)) + 1);
+                    hasFrom.set(true);
+                    return true;
+                }
+                if (input.startsWith("<=")) {
+                    to.set(Integer.parseInt(input.substring(2)));
+                    hasTo.set(true);
+                    return true;
+                }
+                if (input.startsWith("<")) {
+                    to.set(Integer.parseInt(input.substring(1)) - 1);
+                    hasTo.set(true);
+                    return true;
+                }
+                if (input.startsWith("=")) {
+                    int value;
+                    if (input.startsWith("=="))
+                        value = Integer.parseInt(input.substring(2));
+                    else
+                        value = Integer.parseInt(input.substring(1));
+                    from.set(value);
+                    hasFrom.set(true);
+                    to.set(value);
+                    hasTo.set(true);
+                    return true;
+                }
+                if ((input.startsWith("[") || input.startsWith("(")) && (input.endsWith("]") || input.endsWith(")"))) {
+                    boolean startInclusive = input.startsWith("[");
+                    boolean endInclusive = input.endsWith("]");
+                    input = input.substring(1, input.length() - 1);
+                    String[] split = input.split(",", 2);
+                    int start = Integer.parseInt(split[0]);
+                    int end = Integer.parseInt(split[1]);
+                    if (end < start)
+                        return false;
+                    from.set(startInclusive ? start : start + 1);
+                    hasFrom.set(true);
+                    to.set(endInclusive ? end : end - 1);
+                    hasTo.set(true);
+                    return true;
+                }
+                //Unsupported integer range input
+                return false;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        });
+
+        return new StockRequirement(hasFrom.get(), from.get(), hasTo.get(), to.get());
     }
 
+    public record StockRequirement(boolean hasFrom, int from, boolean hasTo, int to) {
+        public boolean satisfied(int stock) {
+            if (hasFrom && hasTo)
+                return stock >= from && stock <= to;
 
+            if (hasFrom)
+                return stock >= from;
+
+            if (hasTo)
+                return stock <= to;
+
+            return true;
+        }
+    }
 }

--- a/src/main/java/io/github/lightman314/lightmanscurrency/common/traders/terminal/filters/BasicSearchFilter.java
+++ b/src/main/java/io/github/lightman314/lightmanscurrency/common/traders/terminal/filters/BasicSearchFilter.java
@@ -17,7 +17,6 @@ public class BasicSearchFilter implements ITraderSearchFilter {
 	public static final String ID = "id";
 	public static final String TRADE_COUNT = "trades";
 	public static final String CUSTOMER_READY = "ready";
-	public static final String STOCK_COUNT = "stock";
 
 	@Override
 	public void filter(TraderData data, PendingSearch search) {
@@ -28,7 +27,6 @@ public class BasicSearchFilter implements ITraderSearchFilter {
 		FilterUtils.longRange(search,ID,data.getID());
 		FilterUtils.intRange(search,TRADE_COUNT,data.validTradeCount());
 		FilterUtils.boolCheck(search,CUSTOMER_READY,data.readyForCustomers());
-		FilterUtils.checkStock(search,data);
 	}
 
 	private Predicate<String> checkType(TraderData trader)

--- a/src/main/java/io/github/lightman314/lightmanscurrency/common/traders/terminal/filters/ItemTraderSearchFilter.java
+++ b/src/main/java/io/github/lightman314/lightmanscurrency/common/traders/terminal/filters/ItemTraderSearchFilter.java
@@ -1,5 +1,8 @@
 package io.github.lightman314.lightmanscurrency.common.traders.terminal.filters;
 
+import io.github.lightman314.lightmanscurrency.api.traders.TradeContext;
+import io.github.lightman314.lightmanscurrency.api.traders.TraderData;
+import io.github.lightman314.lightmanscurrency.api.traders.terminal.FilterUtils;
 import io.github.lightman314.lightmanscurrency.api.traders.terminal.IBasicTraderFilter;
 import io.github.lightman314.lightmanscurrency.api.traders.terminal.ITradeSearchFilter;
 import io.github.lightman314.lightmanscurrency.api.traders.terminal.PendingSearch;
@@ -20,6 +23,16 @@ import java.util.function.Predicate;
 public class ItemTraderSearchFilter implements IBasicTraderFilter {
 
 	public static final String ITEM = "item";
+	public static final String STOCK_COUNT = "stock";
+
+	@Override
+	public void filter(TraderData data, PendingSearch search) {
+		var stockRequirement = FilterUtils.getStockRequirement(search, data);
+		TradeContext context = TradeContext.createStorageMode(data);
+		for(TradeData trade : data.getTradeData())
+			if (stockRequirement.satisfied(trade.getStock(context)))
+				this.filterTrade(trade, search);
+	}
 
 	@Override
 	public void filterTrade(@Nonnull TradeData data, @Nonnull PendingSearch search) {


### PR DESCRIPTION
Currently search by stock works independently from searching by item name while in real world case scenario I want to find a trade that satisfies my need by item name and available stock.

With this PR I merge search by stock with search by name so they work together in searching trades, not traders.
