### PR TITLE
Fix Quark wood variants not registered: move wood type setup before LCConfig.init()

### DIFF
--- a/src/main/java/io/github/lightman314/lightmanscurrency/LightmansCurrency.java
+++ b/src/main/java/io/github/lightman314/lightmanscurrency/LightmansCurrency.java
@@ -32,6 +32,7 @@ import io.github.lightman314.lightmanscurrency.api.traders.terminal.sorting.type
 import io.github.lightman314.lightmanscurrency.api.variants.VariantProvider;
 import io.github.lightman314.lightmanscurrency.api.variants.block.block_entity.IVariantDataStorage;
 import io.github.lightman314.lightmanscurrency.api.variants.block.builtin.VariantChunkDataStorageAttachment;
+
 import io.github.lightman314.lightmanscurrency.common.blocks.MoneyBagBlock;
 import io.github.lightman314.lightmanscurrency.common.core.ModBlocks;
 import io.github.lightman314.lightmanscurrency.common.data.types.TraderDataCache;
@@ -92,6 +93,7 @@ import io.github.lightman314.lightmanscurrency.common.traders.paygate.*;
 import io.github.lightman314.lightmanscurrency.common.traders.rules.types.*;
 import io.github.lightman314.lightmanscurrency.common.traders.terminal.filters.*;
 import io.github.lightman314.lightmanscurrency.common.core.ModRegistries;
+import io.github.lightman314.lightmanscurrency.common.core.variants.WoodType;
 import io.github.lightman314.lightmanscurrency.common.crafting.condition.LCCraftingConditions;
 import io.github.lightman314.lightmanscurrency.common.gamerule.ModGameRules;
 import io.github.lightman314.lightmanscurrency.common.loot.LootManager;
@@ -106,6 +108,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.network.PacketDistributor.PacketTarget;
 
 import javax.annotation.Nonnull;
@@ -123,6 +126,12 @@ public class LightmansCurrency {
     private static final Logger LOGGER = LogManager.getLogger();
 
 	public LightmansCurrency() {
+	
+	    //Setup Wood Compatibilities before registering blocks/items
+		IntegrationUtil.SafeRunIfLoaded("biomesoplenty", BOPCustomWoodTypes::setupWoodTypes, "Error setting up BOP wood types! BOP has probably changed their API!");
+		IntegrationUtil.SafeRunIfLoaded("quark", QuarkCustomWoodTypes::setupWoodTypes, "Error setting up Quark wood types! Quark has probably changed their API!");
+		IntegrationUtil.SafeRunIfLoaded("biomeswevegone", BWGCustomWoodTypes::setupWoodTypes, "Error setting up BWG wood types! BWG has probably changed their API!");
+		//IntegrationUtil.SafeRunIfLoaded("tconstruct", TinkersCustomWoodTypes::setupWoodTypes, "Error setting up Tinkers' Construct wood types! Tinkers has probably changed their API!");
 
 		LootManager.registerDroplistListeners();
 
@@ -130,18 +139,12 @@ public class LightmansCurrency {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::registerCapabilities);
 
-        //Register configs
+		//Register configs
 		LCConfig.init();
 		LootManager.init();
-
-        // Register ourselves for server and other game events we are interested in
+		
+		// Register ourselves for server and other game events we are interested in
         MinecraftForge.EVENT_BUS.register(this);
-
-		//Setup Wood Compatibilities before registering blocks/items
-		IntegrationUtil.SafeRunIfLoaded("biomesoplenty", BOPCustomWoodTypes::setupWoodTypes, "Error setting up BOP wood types! BOP has probably changed their API!");
-		IntegrationUtil.SafeRunIfLoaded("quark", QuarkCustomWoodTypes::setupWoodTypes, "Error setting up Quark wood types! Quark has probably changed their API!");
-		IntegrationUtil.SafeRunIfLoaded("biomeswevegone", BWGCustomWoodTypes::setupWoodTypes, "Error setting up BWG wood types! BWG has probably changed their API!");
-		//IntegrationUtil.SafeRunIfLoaded("tconstruct", TinkersCustomWoodTypes::setupWoodTypes, "Error setting up Tinkers' Construct wood types! Tinkers has probably changed their API!");
 
         //Setup Deferred Registries
         ModRegistries.register(FMLJavaModLoadingContext.get().getModEventBus());


### PR DESCRIPTION
Fix https://github.com/Lightman314/LightmansCurrency/issues/370
Hey,this issue author is my friend,I have helped him solve that issue my fix version works fine.

In the LightmansCurrency constructor, LCConfig.init() executed before the Quark wood type setup. LCConfig.init() triggered a class loading chain: 
LCConfig.Common constructor references ModItems.COIN_EMERALD 
  → triggers ModItems class loading 
  → triggers LCText class loading 
  → triggers ModBlocks class loading. 
The static initialization block of ModBlocks calls registerWooden(), which iterates WoodType.validValues() to register wooden blocks. 
At that point, Quark wood types had not yet been added to WoodType.ALL_TYPES, so all Quark variant blocks (auction_stand_quark_*, bookshelf_trader_quark_*, card_display_quark_*, shelf_quark_*, shelf_2x2_quark_*) were never registered. 
ModBlocks.init() is just an empty method — the static block never runs again, making these blocks permanently missing. 
The differing class loading order between server and client caused a registry mismatch, and Forge reported Missing registry data during the handshake.
So the solution is simple:
Move the wood compatibility initialization code (the setupWoodTypes calls for BOP, Quark, BWG) to the very beginning of the constructor, before LCConfig.init(). 
This way, regardless of whether LCConfig.init() triggers ModBlocks class loading, WoodType.ALL_TYPES already contains all modded wood types, and registerWooden() gets the complete type list.
![Chain Image](https://github.com/user-attachments/assets/981db520-949c-4591-8429-9827478bbc16)

> 给我朋友的中文版本（Chinese version for my friends）:
在 LightmansCurrency 构造函数中 LCConfig.init() 在 Quark 木材类型注册之前执行
LCConfig.init() 会触发一条类加载链：
LCConfig.Common 构造函数引用 ModItems.COIN_EMERALD 
  → 触发 ModItems 类加载 
  → 触发 LCText 类加载 
  → 触发 ModBlocks 类加载
ModBlocks 的静态初始化块调用 registerWooden() 该方法遍历 WoodType.validValues() 来注册木质方块 
此时 Quark 的木材类型尚未添加到 WoodType.ALL_TYPES 因此所有 Quark 变体方块（auction_stand_quark_*、bookshelf_trader_quark_*、card_display_quark_*、shelf_quark_*、shelf_2x2_quark_*）均未被注册
ModBlocks.init() 只是一个空方法 静态初始化块不会再次执行 导致这些方块永久缺失 服务端和客户端因类加载顺序不同产生注册表不一致 Forge 握手时报 Missing registry data
所以解决办法挺简单的：
将木材兼容性初始化代码（BOP、Quark、BWG 的 setupWoodTypes 调用）移到构造函数的最前面 在 LCConfig.init() 之前执行 
这样无论 LCConfig.init() 是否触发 ModBlocks 类加载 WoodType.ALL_TYPES 中都已包含所有模组木材类型 registerWooden() 能获取完整的类型列表 